### PR TITLE
docs: rework README and add full USAGE.md guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,9 @@
 
 [![npm package](https://img.shields.io/npm/v/material-ui-cron/latest.svg)](https://www.npmjs.com/package/material-ui-cron)
 [![MIT License Badge](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/baymac/material-ui-cron/blob/master/LICENSE.md)
+[![Live Demo](https://img.shields.io/badge/live-demo-000?logo=vercel)](https://material-ui-cron.vercel.app/)
 
 A React cron editor built with [material ui](https://material-ui.com/)
-
-For a **live demo**, run the demo app in [`demo/`](./demo):
-
-```bash
-yarn demo:install   # one-time: install the demo app's deps
-yarn demo           # http://localhost:5173
-```
-
-The demo is a small [TanStack Router](https://tanstack.com/router) + Vite SPA that
-imports the component straight from `src/`, so it always reflects the working tree.
 
 ![material-ui-cron demo](/docs/material-ui-cron-demo.png)
 
@@ -23,14 +14,15 @@ imports the component straight from `src/`, so it always reflects the working tr
 
 ## Installation
 
-Be sure that you have these dependencies on your project:
+Be sure that you have these peer dependencies on your project:
 
-- react (>=18.0.0)
-- @mui/material (>=5.15.0)
+- react (>=19.2.0)
+- react-dom (>=19.2.0)
 - @emotion/react (>=11.11.0)
 - @emotion/styled (>=11.11.0)
 
-More dependencies
+`@mui/material` is bundled as a dependency, so you don't need to install it
+separately.
 
 ```bash
 # Yarn
@@ -47,69 +39,41 @@ import Scheduler from 'material-ui-cron'
 import React from 'react'
 
 export default function SchedulerDemo() {
-  const [cronExp, setCronExp] = React.useState('0 0 * * *')
-  const [cronError, setCronError] = React.useState('') // get error message if cron is invalid
-  const [isAdmin, setIsAdmin] = React.useState(true) // set admin or non-admin to enable or disable high frequency scheduling (more than once a day)
+  const [cron, setCron] = React.useState('0 9 * * *')
+  const [cronError, setCronError] = React.useState('') // validation error, '' when valid
 
   return (
     <Scheduler
-      cron={cronExp}
-      setCron={setCronExp}
+      cron={cron}
+      setCron={setCron}
       setCronError={setCronError}
-      isAdmin={isAdmin}
     />
   )
 }
 ```
 
-## TypeScript
+📖 **See [USAGE.md](./USAGE.md) for the full guide** — every prop with examples:
+[theming & dark mode](./USAGE.md#theming-the-color), [admin mode](./USAGE.md#admin-mode-sub-daily-frequencies),
+[layout](./USAGE.md#layout), [title & header](./USAGE.md#title-and-header),
+[timezone](./USAGE.md#timezone), and [localization](./USAGE.md#localization).
 
-`material-ui-cron` is written in TypeScript with complete definitions.
+`material-ui-cron` is written in TypeScript and ships complete type definitions.
 
-## Internalization and Localization
+## Localization
 
-This library supports Internalization (i18n). Currently languages supported are:
+The component ships with **English (`en`)** and **Chinese (`zh_CN`)**, selected
+via the `locale` prop, or supply your own with `customLocale` — see
+[Localization in USAGE.md](./USAGE.md#localization). Translation contributions
+from the community are very welcome.
 
-1. English
-2. Chinese
+### Contributing a translation
 
-We are welcoming translation contributions from the community.
-
-### How to contribute to translation
-
-1. Clone `/src/localization/enLocal.ts` and rename it to desired langauge prefix
-   (based on
+1. Clone `/src/localization/enLocal.ts` and rename it to the desired language
+   prefix (based on
    https://meta.wikimedia.org/wiki/Template:List_of_language_names_ordered_by_code).
-
-2. Add language prefix to `definedLocales` type inside `/src/types.ts` (if required)
-
-3. Add locale mapping inside `/src/i18n.ts`
-
-### How to use translation
-
-#### Using predefined locale:
-
-```javascript
-<Scheduler
-  cron={cronExp}
-  setCron={setCronExp}
-  setCronError={setCronError}
-  isAdmin={isAdmin}
-  locale={'en'} // if not supplied, localization defaults to en
-/>
-```
-
-#### Using custom locale:
-
-```javascript
-<Scheduler
-  cron={cronExp}
-  setCron={setCronExp}
-  setCronError={setCronError}
-  isAdmin={isAdmin}
-  customLocale={{...your translations}} // should be a valid object of type Locale, overrides value supplied to locale prop
-/>
-```
+2. Add the language prefix to the `definedLocales` type inside `/src/types.ts`
+   (if required).
+3. Add the locale mapping inside `/src/i18n.ts`.
 
 ## Testing
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,285 @@
+# Usage
+
+Complete guide to the `<Scheduler />` component — every prop, with examples for
+each variation. For installation and a quick start, see the
+[README](./README.md).
+
+- [Import](#import)
+- [Props](#props)
+- [The controlled value](#the-controlled-value)
+- [Admin mode (sub-daily frequencies)](#admin-mode-sub-daily-frequencies)
+- [Theming the color](#theming-the-color)
+  - [The `color` prop (accent only)](#the-color-prop-accent-only)
+  - [A full MUI theme (dark mode, surfaces, dividers)](#a-full-mui-theme-dark-mode-surfaces-dividers)
+  - [Combining both](#combining-both)
+- [Layout](#layout)
+- [Title and header](#title-and-header)
+- [Timezone](#timezone)
+- [Localization](#localization)
+  - [Predefined locale](#predefined-locale)
+  - [Custom locale](#custom-locale)
+- [Multiple schedulers on one page](#multiple-schedulers-on-one-page)
+- [TypeScript](#typescript)
+
+## Import
+
+The component is the default export. Types are named exports.
+
+```tsx
+import Scheduler from 'material-ui-cron';
+import type { SchedulerProps, SchedulerLayout, Locale, definedLocales } from 'material-ui-cron';
+```
+
+Each `<Scheduler />` manages its own internal state (it creates a private
+[jotai](https://jotai.org/) store on mount), so you can drop several on the same
+page without them stomping on each other — no provider or setup required.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `cron` | `string` | — **(required)** | The controlled cron expression (5-field, e.g. `0 9 * * *`). |
+| `setCron` | `Dispatch<SetStateAction<string>>` | — **(required)** | Called with the new expression whenever the user edits the schedule. |
+| `setCronError` | `Dispatch<SetStateAction<string>>` | — **(required)** | Called with the validation error message (empty string when valid). |
+| `isAdmin` | `boolean` | `false` | Allows sub-daily frequencies (more than once a day). See [Admin mode](#admin-mode-sub-daily-frequencies). |
+| `color` | `string` | theme primary | Accent color (header bar, selected toggle segment, section pills). Any CSS color. See [Theming](#theming-the-color). |
+| `layout` | `'auto' \| 'split' \| 'stacked'` | `'auto'` | Responsive posture of the card. See [Layout](#layout). |
+| `title` | `string` | locale value (`"Schedule"`) | Header title shown next to the calendar icon. |
+| `timezone` | `string` | local zone | IANA timezone for the "Next runs" preview (e.g. `'America/New_York'`). |
+| `locale` | `'en' \| 'zh_CN'` | `'en'` | A built-in translation. See [Localization](#localization). |
+| `customLocale` | `Locale` | — | A full custom translation object. Overrides `locale`. |
+| `slotProps` | `{ header?: { sx?: SxProps<Theme> } }` | — | Per-slot style overrides. See [Title and header](#title-and-header). |
+
+## The controlled value
+
+`<Scheduler />` is a fully controlled component. You own the cron string in
+state and pass it down; the component reports edits back up through `setCron`,
+and validation errors through `setCronError`.
+
+```tsx
+import Scheduler from 'material-ui-cron';
+import React from 'react';
+
+export default function Example() {
+  const [cron, setCron] = React.useState('0 9 * * *'); // daily at 09:00
+  const [cronError, setCronError] = React.useState('');
+
+  return (
+    <>
+      <Scheduler cron={cron} setCron={setCron} setCronError={setCronError} />
+
+      <pre>{cron}</pre>
+      {cronError && <p style={{ color: 'crimson' }}>{cronError}</p>}
+    </>
+  );
+}
+```
+
+Because it is controlled, you can drive it from anywhere — set `cron` to a
+preset and the UI updates to match:
+
+```tsx
+<button onClick={() => setCron('*/15 * * * *')}>Every 15 minutes</button>
+```
+
+## Admin mode (sub-daily frequencies)
+
+By default the editor only allows schedules that run **at most once a day**. Set
+`isAdmin` to allow higher frequencies (every minute, every N minutes, hourly,
+etc.):
+
+```tsx
+<Scheduler
+  cron={cron}
+  setCron={setCron}
+  setCronError={setCronError}
+  isAdmin // unlocks every-minute / every-hour options
+/>
+```
+
+Leave it off (or `false`) to restrict end users to daily-or-coarser schedules.
+
+## Theming the color
+
+There are two ways to recolor the component, depending on how much you want to
+control.
+
+### The `color` prop (accent only)
+
+The quickest way to a different look. `color` overrides the theme's
+`palette.primary` for this card only — it recolors the **header bar**, the
+**selected segment** of the At/Every & On/Every toggles, and the **single-value
+section pills**. The contrast (text) color is recomputed from it automatically,
+so text stays legible against whatever you pass.
+
+```tsx
+<Scheduler
+  cron={cron}
+  setCron={setCron}
+  setCronError={setCronError}
+  color="#7c3aed" // any CSS color: hex, rgb(), hsl(), or a named color
+/>
+```
+
+### A full MUI theme (dark mode, surfaces, dividers)
+
+The Scheduler reads from the standard MUI theme, so anything you set on a parent
+`ThemeProvider` flows in — `palette.primary`, `palette.background.paper` (the
+card surface), `palette.divider` (the row dividers and border), and
+`palette.mode` for dark mode. Use this when you want more than just the accent,
+or when you already have an app-wide theme.
+
+```tsx
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    mode: 'dark', // dark scheduler
+    primary: { main: '#7c3aed' }, // accent
+    background: { paper: '#1a1a1a' }, // card surface
+  },
+});
+
+<ThemeProvider theme={theme}>
+  <Scheduler cron={cron} setCron={setCron} setCronError={setCronError} />
+</ThemeProvider>;
+```
+
+> **Tip:** if you render the scheduler inside a scoped dark region (rather than
+> app-wide), wrap it in MUI's `<ScopedCssBaseline>` so its text and surface
+> colors match an app-wide dark theme. The demo (`demo/src/pages/DemoPage.tsx`)
+> does exactly this.
+
+### Combining both
+
+You can use both together: an app-wide `ThemeProvider` for dark mode / surfaces,
+plus a per-instance `color` for the accent. They merge — the `color` prop is
+applied in a scoped theme nested inside your provider, so it **wins** for
+`palette.primary` while everything else (mode, background, dividers) comes from
+your outer theme.
+
+```tsx
+<ThemeProvider theme={darkTheme}>
+  {/* dark card, but with a teal accent just for this instance */}
+  <Scheduler cron={cron} setCron={setCron} setCronError={setCronError} color="#14b8a6" />
+</ThemeProvider>
+```
+
+## Layout
+
+The card has a two-zone layout: the form on the left and the "Next runs" preview
+on the right. `layout` controls how it responds to width. The card responds to
+**its own width** (via a container query), not the viewport — so it adapts
+correctly even inside a narrow column.
+
+| Value | Behavior |
+| --- | --- |
+| `'auto'` *(default)* | Two columns; stacks to one column when the card is narrower than 720px. |
+| `'split'` | Always two columns. |
+| `'stacked'` | Always one column (Next-runs last). |
+
+```tsx
+<Scheduler cron={cron} setCron={setCron} setCronError={setCronError} layout="stacked" />
+```
+
+## Title and header
+
+`title` sets the text next to the calendar icon in the header bar. It takes
+precedence over the locale's title (which defaults to `"Schedule"`):
+
+```tsx
+<Scheduler cron={cron} setCron={setCron} setCronError={setCronError} title="Run report" />
+```
+
+Use `slotProps.header.sx` to style the header bar itself (a standard MUI `sx`
+object):
+
+```tsx
+<Scheduler
+  cron={cron}
+  setCron={setCron}
+  setCronError={setCronError}
+  slotProps={{ header: { sx: { py: 2 } } }}
+/>
+```
+
+## Timezone
+
+The "Next runs" panel previews upcoming fire times. By default it uses the
+viewer's local zone; pass an IANA timezone to preview against a specific one:
+
+```tsx
+<Scheduler
+  cron={cron}
+  setCron={setCron}
+  setCronError={setCronError}
+  timezone="America/New_York"
+/>
+```
+
+## Localization
+
+The component ships with English (`en`) and Chinese (`zh_CN`). Translation
+contributions are welcome — see the
+[contributing notes](./README.md#contributing-a-translation).
+
+### Predefined locale
+
+```tsx
+<Scheduler
+  cron={cron}
+  setCron={setCron}
+  setCronError={setCronError}
+  locale="zh_CN" // defaults to 'en' when omitted
+/>
+```
+
+> When switching locale at runtime, give the component a `key={locale}` so it
+> remounts and re-renders the field labels in the new language.
+
+### Custom locale
+
+Pass a full `Locale` object to supply your own strings. `customLocale` overrides
+`locale` when both are given:
+
+```tsx
+import type { Locale } from 'material-ui-cron';
+
+const myLocale: Locale = {
+  /* ...a valid Locale object (see src/localization/enLocal.ts for the shape) */
+};
+
+<Scheduler
+  cron={cron}
+  setCron={setCron}
+  setCronError={setCronError}
+  customLocale={myLocale}
+/>;
+```
+
+## Multiple schedulers on one page
+
+No special handling needed — each instance is fully isolated. Render as many as
+you like:
+
+```tsx
+<Scheduler cron={cronA} setCron={setCronA} setCronError={setErrorA} title="Backup" />
+<Scheduler cron={cronB} setCron={setCronB} setCronError={setErrorB} title="Report" color="#e11d48" />
+```
+
+## TypeScript
+
+`material-ui-cron` is written in TypeScript and ships complete type definitions.
+The prop type is exported as `SchedulerProps`:
+
+```tsx
+import type { SchedulerProps } from 'material-ui-cron';
+
+const props: SchedulerProps = {
+  cron,
+  setCron,
+  setCronError,
+  color: '#7c3aed',
+  layout: 'split',
+};
+```


### PR DESCRIPTION
### Select a category

- [ ] New feature
- [ ] Bug fix
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [x] README update
- [x] Other (new USAGE.md guide)

### Related issue link

### Background and solution

Reworks the README and adds a comprehensive `USAGE.md` documenting every `<Scheduler />` prop with examples (controlled value, admin mode, theming/dark mode, layout, title, timezone, localization, multiple instances, and TypeScript). The README now carries a live-demo badge linking to https://material-ui-cron.vercel.app/ in place of the local demo-run instructions, slims the quick-start, and points readers to USAGE.md for the full guide. Installation requirements are updated to the current peer deps (`react`/`react-dom` `>=19.2.0`, with `@mui/material` now bundled as a dependency rather than a peer the user installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)